### PR TITLE
Copy the Multiboot info struct recursively to BSS before enabling paging

### DIFF
--- a/src/kernel/core/Symbols.h
+++ b/src/kernel/core/Symbols.h
@@ -65,6 +65,11 @@ public:
      * @return true, if all kernel symbols have been loaded, false else
      */
     static bool isInitialized();
+    
+    /**
+     * Copy the symbols to memory. (Call before paging is enabled.)
+     */
+    static void copy(const Multiboot::ElfInfo &elfInfo, uint8_t* &destination);
 
 private:
 

--- a/src/kernel/core/constants.asm
+++ b/src/kernel/core/constants.asm
@@ -17,5 +17,6 @@
 
 %define KERNEL_START     0xC0000000
 %define STACK_SIZE       0x00004000
+%define MULTIBOOT_SIZE   512 * 1024
 
 %endif


### PR DESCRIPTION
The information passed by the bootloader may be anywhere in memory and it also contains pointers. We can't be sure to still have access after enabling paging, so lets copy it recursively to BSS.

This doesn't copy ELF sections that aren't symbols or strings.
Also, it may write past the end of the allocated memory in case of very large command lines or symbol tables.
It would be good if at least the `assert` could be used.