### PR TITLE
"wc" Shell Command

### DIFF
--- a/cmake/application/shell/CMakeLists.txt
+++ b/cmake/application/shell/CMakeLists.txt
@@ -50,4 +50,5 @@ target_sources(application PUBLIC
         ${HHUOS_SRC_DIR}/application/shell/command/Touch.cpp
         ${HHUOS_SRC_DIR}/application/shell/command/Umount.cpp
         ${HHUOS_SRC_DIR}/application/shell/command/Uptime.cpp
-        ${HHUOS_SRC_DIR}/application/shell/command/WavPlay.cpp)
+        ${HHUOS_SRC_DIR}/application/shell/command/WavPlay.cpp
+        ${HHUOS_SRC_DIR}/application/shell/command/WordCount.cpp)

--- a/src/application/shell/Shell.cpp
+++ b/src/application/shell/Shell.cpp
@@ -55,6 +55,7 @@
 #include "application/shell/command/Asciimate.h"
 #include "device/port/PortEvent.h"
 #include "application/shell/command/NetworkTest.h"
+#include "application/shell/command/WordCount.h"
 
 extern "C" {
 #include "lib/libc/ctype.h"
@@ -103,6 +104,7 @@ Shell::Shell() : KernelThread("Shell") {
     commands.put("license", new License(*this));
     commands.put("asciimate", new Asciimate(*this));
     commands.put("nettest", new NetworkTest(*this));
+    commands.put("wc", new WordCount(*this));
 
     memset(inputBuffer, 0, sizeof(inputBuffer));
 }

--- a/src/application/shell/command/WordCount.cpp
+++ b/src/application/shell/command/WordCount.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2018 Burak Akguel, Christian Gesse, Fabian Ruhland, Filip Krakowski, Michael Schoettner
+ * Heinrich-Heine University
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include "lib/file/FileStatus.h"
+#include "WordCount.h"
+#include "lib/file/File.h"
+#include "lib/file/FileStatus.h"
+#include <cctype>
+
+void WordCount::execute(Util::Array<String> &args) {
+
+    Util::ArrayList<String> paths;
+
+    Util::ArgumentParser parser(getHelpText(), 1);
+
+    parser.addSwitch("lines", "l");
+    parser.addSwitch("words","w");
+    parser.addSwitch("bytes","c");
+
+    if(!parser.parse(args)) {
+        stderr << args[0] << ": " << parser.getErrorString() << endl;
+        return;
+    }
+
+    for(const String &path : parser.getUnnamedArguments()) {
+        paths.add(path);
+    }
+
+    for(const String &path : paths) {
+        String absolutePath = calcAbsolutePath(path);
+
+        if (FileStatus::exists(absolutePath)) {
+            FileStatus *fStat = FileStatus::stat(absolutePath);
+
+            if (fStat->getFileType() != FsNode::DIRECTORY_FILE) {
+
+                count(absolutePath, &parser);
+            }
+            delete fStat;
+
+        } else {
+            stderr << args[0] << " '" << path << "': File not found!" << endl;
+        }
+    }
+
+    if(paths.size() > 1){
+        wcPrintTotal(&parser);
+    }
+}
+
+void WordCount::wcPrintTotal(Util::ArgumentParser* parser) {
+
+    if(parser->checkSwitch("lines")){
+        stdout << linesTotal << " ";
+    }else if(parser->checkSwitch("words")){
+        stdout << wordsTotal << " ";
+    }else if(parser->checkSwitch("bytes")){
+        stdout << bytesTotal << " ";
+    }else{
+        stdout
+                << linesTotal << " "
+                << wordsTotal << " "
+                << bytesTotal << " ";
+    }
+
+    stdout << "total";
+
+    stdout << endl;
+    stdout.flush();
+}
+
+void WordCount::count(const String &absolutePath, Util::ArgumentParser* parser) {
+
+    bytes = 0;
+    words = 0;
+    lines = 0;
+
+    File *file = File::open(absolutePath, "r");
+
+    char c;
+    uint32_t currentWordLength = 0;
+
+    while((c = file->readChar()) != FsNode::END_OF_FILE){
+
+        for(size_t i = 0; i < file->getLength(); i++){
+
+            switch (c) {
+                case '\n':
+                    lines++;
+                    currentWordLength = 0;
+                    break;
+                case ' ':
+                case '\t':
+                    if(currentWordLength > 0)
+                        words++;
+
+                    currentWordLength = 0;
+                default:
+                    if(isprint(c))
+                        currentWordLength++;
+                    else
+                        currentWordLength = 0;
+                    break;
+            }
+
+            bytes++;
+        }
+    }
+
+    bytesTotal += bytes;
+    wordsTotal += words;
+    linesTotal += lines;
+
+    wcPrintStats(parser, file);
+
+    delete file;
+}
+
+void WordCount::wcPrintStats(Util::ArgumentParser* parser, File *pFile) {
+
+    if(parser->checkSwitch("lines")){
+        stdout << lines << " ";
+    }else if(parser->checkSwitch("words")){
+        stdout << words << " ";
+    }else if(parser->checkSwitch("bytes")){
+        stdout << bytes << " ";
+    }else{
+        stdout
+        << lines << " "
+        << words << " "
+        << bytes << " ";
+    }
+
+    stdout << pFile->getName();
+
+    stdout << endl;
+    stdout.flush();
+}
+
+const String WordCount::getHelpText(){
+    return "Counts the Bytes, Words and Lines in File(s)\n\n"
+           "Usage: wc [OPTION]... [PATH]...\n\n"
+           "Options:\n"
+           "  -c, --bytes: count only bytes\n"
+           "  -w, --words: count only words\n"
+           "  -l, --lines: count only newlines\n"
+           "  -h, --help: Show this help-message.";
+}
+
+WordCount::WordCount(Shell &shell) : Command(shell) {
+
+}

--- a/src/application/shell/command/WordCount.h
+++ b/src/application/shell/command/WordCount.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2018 Burak Akguel, Christian Gesse, Fabian Ruhland, Filip Krakowski, Michael Schoettner
+ * Heinrich-Heine University
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef HHUOS_WORDCOUNT_H
+#define HHUOS_WORDCOUNT_H
+
+#include "lib/stream/OutputStream.h"
+#include "lib/string/String.h"
+#include "Command.h"
+#include "lib/file/File.h"
+
+/**
+ * Implementation of Command.
+ * Counts Bytes, Words and Lines in a File
+ *
+ * -h, --help: Show help message
+ *
+ * @author Alexander Hansen
+ * @date 2022
+ */
+class WordCount : public Command {
+
+public:
+    /**
+     * Constructor.
+     *
+     * @param shell The shell, that executes this command
+     */
+    explicit WordCount(Shell &shell);
+
+    /**
+     * Overriding function from Command.
+     */
+    void execute(Util::Array<String> &args) override;
+
+    /**
+     * Overriding function from Command.
+     */
+    const String getHelpText() override;
+
+private:
+    size_t bytes = 0;
+    size_t words = 0;
+    size_t lines = 0;
+
+    size_t bytesTotal = 0;
+    size_t wordsTotal = 0;
+    size_t linesTotal = 0;
+
+    void count(const String &absolutePath, Util::ArgumentParser* parser);
+
+    void wcPrintStats(Util::ArgumentParser* parser, File *pFile);
+
+    void wcPrintTotal(Util::ArgumentParser* parser);
+};
+
+#endif //HHUOS_WORDCOUNT_H

--- a/src/application/shell/command/WordCount.h
+++ b/src/application/shell/command/WordCount.h
@@ -52,9 +52,6 @@ public:
     const String getHelpText() override;
 
 private:
-    size_t bytes = 0;
-    size_t words = 0;
-    size_t lines = 0;
 
     size_t bytesTotal = 0;
     size_t wordsTotal = 0;
@@ -62,7 +59,7 @@ private:
 
     void count(const String &absolutePath, Util::ArgumentParser* parser);
 
-    void wcPrintStats(Util::ArgumentParser* parser, File *pFile);
+    void wcPrintStats(Util::ArgumentParser *parser, File *pFile, size_t bytes, size_t words, size_t lines);
 
     void wcPrintTotal(Util::ArgumentParser* parser);
 };


### PR DESCRIPTION
Here is an implementation of 'wc' .

In Regard to character count and line count, it is the same as the regular wc.

With word count, it deviates a little from the output of my wc (GNU coreutils) 8.32.

However i don't see it as a problem, as even wc itself does vary in their definition of what a 'word' 
is (https://fossies.org/diffs/coreutils/8.32_vs_9.0/man/wc.1-diff.html), and subsequently their output. And i did not want to create a copy of the gnu implementation.

Any Feedback would be appreciated :)

