### PR TITLE
APIC: Don't depend on sequential local APIC IDs or existing local APIC NMIs

### DIFF
--- a/src/device/cpu/symmetric_multiprocessing.asm
+++ b/src/device/cpu/symmetric_multiprocessing.asm
@@ -31,6 +31,7 @@ global boot_ap_idtr
 global boot_ap_cr0
 global boot_ap_cr3
 global boot_ap_cr4
+global boot_ap_counter ; This is used to identify an APs GDT/Stack and "runningAPs" entry
 global boot_ap_gdts
 global boot_ap_stacks
 global boot_ap_entry
@@ -108,6 +109,9 @@ align 8
 boot_ap_cr4:
     dd 0x0
 align 8
+boot_ap_counter:
+    dd 0x0
+align 8
 boot_ap_gdts:
     dd 0x0
 align 8
@@ -137,10 +141,14 @@ boot_ap_32:
     ; lgdt [boot_ap_gdtr - boot_ap + startup_address]
 
     ; Get the local APIC ID of this AP, to locate GDT and stack
-    mov eax, 0x1
-    cpuid
-    shr ebx, 0x18
-    mov edi, ebx ; Now the ID is in EDI
+    ; mov eax, 0x1
+    ; cpuid
+    ; shr ebx, 0x18
+    ; mov edi, ebx ; Now the ID is in EDI
+
+    ; Get the initializedApplicationProcessorsCounter value to identify GDT and Stack
+    mov eax, [boot_ap_counter - boot_ap + startup_address]
+    mov edi, [eax]
 
     ; Load the AP's prepared GDT and TSS
     mov ebx, [boot_ap_gdts - boot_ap + startup_address] ; GDT descriptor array

--- a/src/device/cpu/symmetric_multiprocessing.cpp
+++ b/src/device/cpu/symmetric_multiprocessing.cpp
@@ -30,7 +30,7 @@ volatile bool runningApplicationProcessors[256]{}; // Once an AP is running it s
 
 Kernel::Logger log = Kernel::Logger::get("SMP");
 
-[[noreturn]] void applicationProcessorEntry(uint8_t apicId) {
+[[noreturn]] void applicationProcessorEntry(uint8_t initializedApplicationProcessorsCounter) {
     // Initialize this AP's APIC
     auto &interruptService = Kernel::System::getService<Kernel::InterruptService>();
     auto &apic = interruptService.getApic();
@@ -39,7 +39,7 @@ Kernel::Logger log = Kernel::Logger::get("SMP");
     // Disabled, since it causes a memory allocation
     // apic.startCurrentTimer();
 
-    runningApplicationProcessors[apicId] = true; // Mark this AP as running
+    runningApplicationProcessors[initializedApplicationProcessorsCounter] = true; // Mark this AP as running
 
     // Enable interrupts for this AP (usually results in a crash)
     // asm volatile ("sti");

--- a/src/device/cpu/symmetric_multiprocessing.h
+++ b/src/device/cpu/symmetric_multiprocessing.h
@@ -31,6 +31,7 @@ extern Device::Cpu::Descriptor boot_ap_idtr;
 extern uint32_t boot_ap_cr0;
 extern uint32_t boot_ap_cr3;
 extern uint32_t boot_ap_cr4;
+extern volatile uint32_t boot_ap_counter;
 extern volatile uint32_t boot_ap_gdts;   // Not written by asm volatile (), so add volatile here
 extern volatile uint32_t boot_ap_stacks; // Not written by asm volatile (), so add volatile here
 extern volatile uint32_t boot_ap_entry;  // Not written by asm volatile (), so add volatile here
@@ -38,9 +39,7 @@ extern volatile uint32_t boot_ap_entry;  // Not written by asm volatile (), so a
 namespace Device {
 
 // Export to symmetric_multiprocessing.asm
-extern "C" [[noreturn]] void applicationProcessorEntry(uint8_t apicId);
-// This is used as a bitmap, once an AP is running it sets its corresponding bit to 1.
-// MPSpec requires the ids to be sequential (sec. B.4), so it works for a max. of 64 CPUs.
+extern "C" [[noreturn]] void applicationProcessorEntry(uint8_t initializedApplicationProcessorsCounter);
 extern "C" volatile bool runningApplicationProcessors[256];
 
 // If any of these two are changed, smp.asm has to be changed too (the %defines at the top)!

--- a/src/device/interrupt/apic/Apic.cpp
+++ b/src/device/interrupt/apic/Apic.cpp
@@ -286,7 +286,7 @@ void Apic::startupApplicationProcessors() {
     void *gdtPointers = prepareApplicationProcessorGdts();
     void *stackPointers = prepareApplicationProcessorStacks();
     void *startupCodeRegion = prepareApplicationProcessorStartupCode(gdtPointers, stackPointers);
-    void *warmResetVectorRegion = prepareApplicationProcessorStacks(); // This is technically only required for discrete APIC, see below
+    void *warmResetVectorRegion = prepareApplicationProcessorWarmReset(); // This is technically only required for discrete APIC, see below
 
     // Universal Startup Algorithm requires all interrupts disabled (they should be disabled anyway, but disabling them a second time is twice as good)
     Cpu::disableInterrupts();

--- a/src/device/interrupt/apic/Apic.h
+++ b/src/device/interrupt/apic/Apic.h
@@ -29,6 +29,7 @@
 #include "lib/util/collection/ArrayList.h"
 #include "device/time/ApicTimer.h"
 #include "device/cpu/Cpu.h"
+#include "lib/util/collection/HashMap.h"
 
 namespace Device {
 
@@ -38,7 +39,7 @@ public:
     /**
      * Constructor.
      */
-    Apic(const Util::Array<LocalApic*> &localApics, IoApic *ioApic);
+    Apic(const Util::Array<LocalApic*> &localApicsArray, IoApic *ioApic);
 
     /**
      * Copy Constructor.
@@ -175,8 +176,8 @@ private:
     // Memory allocated for or by instances contained in these lists is never freed,
     // this implementation doesn't support disabling the APIC at all.
     // Once the switch from PIC to APIC is done, it can't be switched back.
-    Util::Array<LocalApic*> localApics;  // All LocalApic instances.
-    Util::Array<ApicTimer*> localTimers; // All ApicTimer instances.
+    Util::HashMap<uint8_t, LocalApic*> localApics;  // All LocalApic instances.
+    Util::HashMap<uint8_t, ApicTimer*> localTimers; // All ApicTimer instances.
     IoApic *ioApic;                      // The IoApic instance responsible for the external interrupts.
     LocalApicErrorHandler errorHandler;  // The interrupt handler that gets triggered on an internal APIC error.
 

--- a/src/device/interrupt/apic/LocalApic.cpp
+++ b/src/device/interrupt/apic/LocalApic.cpp
@@ -43,25 +43,11 @@ LocalApic::LocalApic(uint8_t cpuId, LocalApic::LocalInterrupt nmiLint, LocalApic
     cpuId(cpuId), nmiLint(nmiLint), nmiPolarity(nmiPolarity), nmiTrigger(nmiTrigger) {}
 
 bool LocalApic::supportsXApic() {
-    auto features = Util::Hardware::CpuId::getCpuFeatures();
-    for (auto feature : features) {
-        if (feature == Util::Hardware::CpuId::CpuFeature::APIC) {
-            return true;
-        }
-    }
-
-    return false;
+    return (Util::Hardware::CpuId::getCpuFeatureBits() & Util::Hardware::CpuId::APIC) != 0;
 }
 
 bool LocalApic::supportsX2Apic() {
-    auto features = Util::Hardware::CpuId::getCpuFeatures();
-    for (auto feature : features) {
-        if (feature == Util::Hardware::CpuId::CpuFeature::X2APIC) {
-            return true;
-        }
-    }
-
-    return false;
+    return (Util::Hardware::CpuId::getCpuFeatureBits() & Util::Hardware::CpuId::X2APIC) != 0;
 }
 
 uint8_t LocalApic::getId() {

--- a/src/device/interrupt/apic/LocalApic.h
+++ b/src/device/interrupt/apic/LocalApic.h
@@ -28,6 +28,7 @@
 #include "lib/util/async/Spinlock.h"
 #include "kernel/log/Logger.h"
 #include "device/cpu/ModelSpecificRegister.h"
+#include "lib/util/collection/ArrayList.h"
 
 namespace Device {
 
@@ -209,10 +210,18 @@ public:
         explicit operator uint64_t() const;
     };
 
+    struct NmiSource {
+        LocalInterrupt source;                       // The local interrupt pin that acts as NMI source.
+        LocalVectorTableEntry::PinPolarity polarity; // The NMI source's pin polarity.
+        LocalVectorTableEntry::TriggerMode trigger;  // The NMI source's trigger mode.
+
+        bool operator!=(const NmiSource &other) const;
+    };
+
     /**
      * Constructor.
      */
-    LocalApic(uint8_t cpuId, LocalApic::LocalInterrupt nmiLint, LocalApic::LocalVectorTableEntry::PinPolarity nmiPolarity, LocalApic::LocalVectorTableEntry::TriggerMode nmiTrigger);
+    explicit LocalApic(uint8_t cpuId);
 
     /**
      * Copy Constructor.
@@ -345,6 +354,8 @@ public:
      */
     static void initializeLocalVectorTable();
 
+    void addNonMaskableInterrupt(LocalInterrupt nmiLint, LocalVectorTableEntry::PinPolarity nmiPolarity, LocalVectorTableEntry::TriggerMode nmiTrigger);
+
     /**
      * Read the IA32_APIC_BASE_MSR.
      *
@@ -426,10 +437,8 @@ public:
 
 private:
 
-    uint8_t cpuId;                                  // The CPU core this instance belongs to, LocalApic::getId() only returns the current AP's id!
-    LocalInterrupt nmiLint;                         // The local interrupt pin that acts as NMI source.
-    LocalVectorTableEntry::PinPolarity nmiPolarity; // The NMI source's pin polarity.
-    LocalVectorTableEntry::TriggerMode nmiTrigger;  // The NMI source's trigger mode.
+    uint8_t cpuId; // The CPU core this instance belongs to, LocalApic::getId() only returns the current AP's id!
+    Util::ArrayList<NmiSource> nmiSources;
 
     static uint32_t mmioAddress; // The virtual address used to access registers in xApic mode.
 

--- a/src/device/time/ApicTimer.cpp
+++ b/src/device/time/ApicTimer.cpp
@@ -91,4 +91,8 @@ void ApicTimer::calibrate() {
     log.info("Apic Timer ticks per millisecond: [%u]", ticksPerMilliseconds);
 }
 
+uint8_t ApicTimer::getCpuId() const {
+    return cpuId;
+}
+
 }

--- a/src/device/time/ApicTimer.h
+++ b/src/device/time/ApicTimer.h
@@ -105,6 +105,8 @@ public:
      */
     static void calibrate();
 
+    [[nodiscard]] uint8_t getCpuId() const;
+
 private:
     uint8_t cpuId;          // The id of the CPU that uses this timer.
     uint32_t timerInterval; // The interrupt trigger interval in milliseconds.

--- a/src/kernel/system/System.cpp
+++ b/src/kernel/system/System.cpp
@@ -111,7 +111,7 @@ void System::initializeSystem() {
             interruptService->useApic(apic);
         }
 
-        if (apic->isSymmetricMultiprocessingSupported()) {
+        if (apic != nullptr && apic->isSymmetricMultiprocessingSupported()) {
             apic->startupApplicationProcessors();
         }
     } else {


### PR DESCRIPTION
I tried to run hhuOS on my ThinkPad (T440s) and noticed some wrong assumptions I apparently made when programming the APIC:

1. The local APIC Ids might not be sequential:
    - This breaks most things APIC related, as local APICs and local timers are stored in arrays, indexed by their Id
    - The same applies for AP GDTs and stacks on SMP bootup
2. Not every local APIC receives an ACPI NMI definition, it is not even required to use ACPI for this:
    - Logical cores (hyperthreading) don't receive NMIs, but each logical core has its own local APIC Id
    - The NMI configuration is already specified in MP/IA-32 specifications, it doesn't have to rely on ACPI
    - The NMI configurations specified by ACPI might not be accurate (T440s weirdly reports the wrong type of Id for NMI target local APICs, so NMI can't be assigned to local APIC)

Co-authored-by: Christoph Urlacher <christoph.urlacher@protonmail.com>